### PR TITLE
Add Global API Key Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ import (
 
 func main() {
     // Initialize client with options
-    client := erlcgo.NewClient("your-api-key",
+    client := erlcgo.NewClient("your-server-key",
         erlcgo.WithTimeout(time.Second*15),
         erlcgo.WithRequestQueue(2, time.Second),
+        erlcgo.WithGlobalAPIKey("your-global-key"), // Optional global API key
         erlcgo.WithCache(&erlcgo.CacheConfig{
             Enabled: true,
             TTL:     time.Minute,
@@ -99,10 +100,31 @@ func main() {
 }
 ```
 
+## Authentication
+
+The ERLC API uses two types of API keys:
+
+- **Server Key** (required): Identifies your specific server and is sent in the `Server-Key` header
+- **Global API Key** (optional): Provides higher rate limits for large applications and is sent in the `Authorization` header
+
+
+```go
+// Without global API key
+client := erlcgo.NewClient("your-server-key")
+
+// With global API key (for large applications serving 150+ servers)
+client := erlcgo.NewClient("your-server-key",
+    erlcgo.WithGlobalAPIKey("your-global-key"),
+)
+```
+
 ## Client Configuration
 
 ```go
-client := erlcgo.NewClient("your-api-key",
+client := erlcgo.NewClient("your-server-key",
+    // Global API key (optional)
+    erlcgo.WithGlobalAPIKey("your-global-key"),
+
     // Custom HTTP client
     erlcgo.WithHTTPClient(&http.Client{
         Timeout: time.Second * 30,
@@ -268,7 +290,7 @@ client := erlcgo.NewClient("your-api-key",
 2. **Handle Rate Limits**
 
    ```go
-   client := erlcgo.NewClient("your-api-key",
+   client := erlcgo.NewClient("your-server-key",
        erlcgo.WithRequestQueue(1, time.Second),
    )
    ```
@@ -276,7 +298,7 @@ client := erlcgo.NewClient("your-api-key",
 3. **Enable Caching**
 
    ```go
-   client := erlcgo.NewClient("your-api-key",
+   client := erlcgo.NewClient("your-server-key",
        erlcgo.WithCache(&erlcgo.CacheConfig{
            Enabled: true,
            TTL:    time.Minute * 5,

--- a/api.go
+++ b/api.go
@@ -175,6 +175,11 @@ func (c *Client) doRequest(req *http.Request, v interface{}) error {
 		return fmt.Errorf("API key is empty")
 	}
 
+	// Set global API key in Authorization header if provided
+	if c.globalAPIKey != "" {
+		req.Header.Set("Authorization", c.globalAPIKey)
+	}
+
 	if c.cache != nil && c.cache.Enabled {
 		if c.cache.Cache == nil {
 			c.cache.Cache = NewMemoryCache()

--- a/client.go
+++ b/client.go
@@ -2,7 +2,12 @@
 //
 // Basic usage:
 //
-//	client := erlcgo.NewClient("your-api-key")
+//	client := erlcgo.NewClient("your-server-key")
+//
+//	// With optional global API key:
+//	client := erlcgo.NewClient("your-server-key",
+//	    erlcgo.WithGlobalAPIKey("your-global-key"),
+//	)
 //
 //	// Get players
 //	players, err := client.GetPlayers(context.Background())
@@ -20,29 +25,31 @@ import (
 // It handles authentication, rate limiting, and request execution.
 // Create a new client using NewClient().
 type Client struct {
-	httpClient  *http.Client
-	baseURL     string
-	apiKey      string
-	rateLimiter *RateLimiter
-	queue       *RequestQueue
-	cache       *CacheConfig
+	httpClient   *http.Client
+	baseURL      string
+	apiKey       string
+	globalAPIKey string
+	rateLimiter  *RateLimiter
+	queue        *RequestQueue
+	cache        *CacheConfig
 }
 
 // ClientOption allows customizing the client's behavior.
 // Use the With* functions to create options.
 type ClientOption func(*Client)
 
-// NewClient creates a new ERLC API client with the given API key and options.
+// NewClient creates a new ERLC API client with the given server key and options.
 //
 // Example:
 //
-//	client := NewClient("your-api-key",
+//	client := NewClient("your-server-key",
 //	    WithTimeout(time.Second*15),
 //	    WithBaseURL("https://custom-url.com"),
+//	    WithGlobalAPIKey("your-global-key"),
 //	)
 func NewClient(apiKey string, opts ...ClientOption) *Client {
 	if apiKey == "" {
-		panic("API key is required")
+		panic("server key is required")
 	}
 
 	// Create default cache config but disable it by default
@@ -124,5 +131,19 @@ func WithRequestQueue(workers int, interval time.Duration) ClientOption {
 func WithCache(config *CacheConfig) ClientOption {
 	return func(c *Client) {
 		c.cache = config
+	}
+}
+
+// WithGlobalAPIKey sets a global API key for higher rate limits.
+// The global API key is sent in the Authorization header.
+//
+// Example:
+//
+//	client := NewClient("your-server-key",
+//	    WithGlobalAPIKey("your-global-key"),
+//	)
+func WithGlobalAPIKey(globalAPIKey string) ClientOption {
+	return func(c *Client) {
+		c.globalAPIKey = globalAPIKey
 	}
 }


### PR DESCRIPTION
## Support for Optional Global API Key
This PR adds support for an optional global API key to provide higher rate limits for large applications. The global API key is sent in the `Authorization` header alongside the existing `Server-Key` header:

```go
// Without global API key (existing behavior)
client := erlcgo.NewClient("your-server-key")

// With optional global API key
client := erlcgo.NewClient("your-server-key",
    erlcgo.WithGlobalAPIKey("your-global-key"),
)
```

Additionally, I updated the documentation to include usage examples for this new change. This is a pretty straightforward new feature.